### PR TITLE
Centered board items

### DIFF
--- a/src/app/board/page.js
+++ b/src/app/board/page.js
@@ -8,7 +8,7 @@ const Page = () => {
       <div className="flex justify-center items-center p-3">
         <div className="grid grid-cols-1 gap-y-10">
           <Title text="Get To Know Us" color="green" />
-          <div className="grid xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-y-16 gap-x-32">
+          <div className="grid justify-items-center xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-y-16 gap-x-32">
             {BOARD.map((boardMember, index) => (
               <Board
                 key={index}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8b6138f5-629c-4bd5-96eb-4e47eaeee721)

Used justify-items-center, seemed to slightly change spacing on some of the larger breakpoints too